### PR TITLE
Marcelo

### DIFF
--- a/src/main/java/com/veterinaria/entity/ApplicationEnums.java
+++ b/src/main/java/com/veterinaria/entity/ApplicationEnums.java
@@ -8,7 +8,7 @@ public class ApplicationEnums {
         ANIMAL_FAZENDA,
         ANIMAL_DOMESTICO_FAZENDA,
         ANIMAL_SELVAGEM,
-        TUTTI
+        TODOS
     }
 
     enum tipoAnimal

--- a/src/main/java/com/veterinaria/entity/ApplicationEnums.java
+++ b/src/main/java/com/veterinaria/entity/ApplicationEnums.java
@@ -1,0 +1,20 @@
+package com.veterinaria.entity;
+
+public class ApplicationEnums {
+
+    enum especialidadeMedico
+    {
+        ANIMAL_DOMESTICO,
+        ANIMAL_FAZENDA,
+        ANIMAL_DOMESTICO_FAZENDA,
+        ANIMAL_SELVAGEM,
+        TUTTI
+    }
+
+    enum tipoAnimal
+    {
+        DOMESTICO,
+        FAZENDA,
+        SELVAGEM
+    }
+}

--- a/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
+++ b/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+
 public class MedicoPersistence {
 
 

--- a/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
+++ b/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
@@ -1,0 +1,134 @@
+package com.veterinaria.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.veterinaria.entity.Medico;
+import com.veterinaria.entity.Proprietario;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class MedicoPersistence {
+
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    //pra quê a lista? pegar os json da persistência e reescrever, né?
+    private List<Medico> medicos = new ArrayList<>();
+
+
+    private void mapearObjeto(){
+        mapper.findAndRegisterModules();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+
+    private boolean cpfNaoUtilizado(String cpf){
+
+        //iterar
+        for (Medico medico : listarMedicos()){
+            if (medico.getCpf().equals(cpf)){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean crmNaoUtilizado(String crm){
+
+        //iterar
+        for (Medico medico : listarMedicos()){
+            if (medico.getCpf().equals(crm)){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean cpfOuCrNaoUtilizado(String cpf, Integer crm)
+    {
+        boolean jaCadastrado
+                =  listarMedicos().stream()
+                .filter(x-> x.getCpf().equals(cpf) || x.getNumeroRegistro().equals(crm))
+                .count() == 0;
+
+        return jaCadastrado;
+    }
+
+    /**
+     * metodo adiciona o objeto na lista
+     * e salva em um arquivo json.
+     */
+
+    public Medico cadastrar(Medico medico){
+        if (cpfOuCrNaoUtilizado(medico.getCpf(), medico.getNumeroRegistro())){
+            mapearObjeto();
+            medicos.add(medico);
+            try {
+                mapper.writeValue(new File("medicos.json"), medicos);
+            }catch (IOException e){
+                e.printStackTrace();
+            }
+        }
+        return medico;
+    }
+
+    /**
+     * metodo mapea o objeto e
+     * localiza no arquivo de cadastro
+     */
+//    public Medico obterUm(String cpf){
+//        mapearObjeto();
+//        medicos = listarMedicos();
+//        Optional<Medico> optionalMedico = medicos.stream()
+//                .filter(p -> p.getCpf().equals(cpf)).findFirst();
+//        return optionalMedico.orElse(null);
+//    }
+
+    public Medico obterUm(Integer numRegistro){
+        mapearObjeto();
+        medicos = listarMedicos();
+        Optional<Medico> optionalMedico = medicos.stream()
+                .filter(p -> p.getCpf().equals(numRegistro)).findFirst();
+        return optionalMedico.orElse(null);
+    }
+
+
+
+
+    /**
+     * metodo faz a leitura de todos os objetos da lista
+     */
+    public List<Medico> listarMedicos(){
+        mapearObjeto();
+        try {
+            medicos = mapper.readValue(new File("medicos.json"), new TypeReference<List<Medico>>(){});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return medicos;
+    }
+
+    public Medico delete(Integer crm)
+    {
+        Medico m = obterUm(crm);
+        medicos.remove(m);
+        try {
+            mapper.writeValue(new File("medicos.json"), medicos);
+        }catch (IOException e){
+            e.printStackTrace();
+        }
+
+        return m;
+
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
+++ b/src/main/java/com/veterinaria/persistence/MedicoPersistence.java
@@ -51,12 +51,12 @@ public class MedicoPersistence {
 
     private boolean cpfOuCrNaoUtilizado(String cpf, Integer crm)
     {
-        boolean jaCadastrado
+        boolean naoCadastrado
                 =  listarMedicos().stream()
                 .filter(x-> x.getCpf().equals(cpf) || x.getNumeroRegistro().equals(crm))
                 .count() == 0;
 
-        return jaCadastrado;
+        return naoCadastrado;
     }
 
     /**


### PR DESCRIPTION
Finalizada MedicoPersistence. ao método cadastrar().
 
Substituí o método de verificação de duplicidade para que agora possamos ter tanto a verificação de duplicidade de CRM quanto de CPF, mas ainda sim mantendo declarado cpfNaoUtilizado(), e de brinde um crmNaoUtilizado() caso eventualmente precisemos verificar estes campos individualmente.

Sujeito a alterações decididas em grupo .

---`-,-;{@